### PR TITLE
Change colour of input when renaming files

### DIFF
--- a/Material/theme.css
+++ b/Material/theme.css
@@ -558,3 +558,10 @@ select.elfinder-tabstop.ui-state-hover {
 .elfinder-dialog-icon-preupload,
 .elfinder-dialog-icon-url,
 .elfinder-dialog-icon-dim         { background-position: 0 -416px !important; }
+
+/**
+* Rename file input box
+*/
+.elfinder-cwd-filename input {
+	color:#000;
+}


### PR DESCRIPTION
When you right-click a file and select rename, it opens a input type=text box. Initially it appears fine as the text is highlighted, but as soon as you click to edit it or type something the colour was white text on white background so unreadable. Change text to black.